### PR TITLE
Correct set picture success handling

### DIFF
--- a/yowsup/layers/protocol_profiles/layer.py
+++ b/yowsup/layers/protocol_profiles/layer.py
@@ -38,7 +38,7 @@ class YowProfilesProtocolLayer(YowProtocolLayer):
         self.toUpper(ErrorIqProtocolEntity.fromProtocolTreeNode(errorNode))
 
     def onSetPictureResult(self, resultNode, originalIqRequestEntity):
-        self.toUpper(ResultIqProtocolEntity.fromProtocolTreeNode(resultNode))
+        self.toUpper(ResultGetPictureIqProtocolEntity.fromProtocolTreeNode(resultNode))
 
     def onSetPictureError(self, errorNode, originalIqRequestEntity):
         self.toUpper(ErrorIqProtocolEntity.fromProtocolTreeNode(errorNode))


### PR DESCRIPTION
This way you can do this to get the just set picture ID:

``` python
def success(resultIq, requestIq):
  picId = resultIq.getPictureId()

iq = SetPictureIqProtocolEntity(myJid, previewData, pictureData)
self._sendIq(iq, success)
```

Without this patch, you can't get the picture ID because it parses the stanza into a simple `ResultIqProtocolEntity`.
